### PR TITLE
Changes to match WiFi AP config for ultra96-v2 board

### DIFF
--- a/recipes-utils/ultra96-ap-setup/files/ap.sh
+++ b/recipes-utils/ultra96-ap-setup/files/ap.sh
@@ -29,31 +29,55 @@
 #
 # ******************************************************************************
 
+#Load the kernel module for the WILC3000 WiFi 
+modprobe wilc-sdio
+
+#The WILC3000 supports 2 interfaces
+#--p2p0 for use as an access point
+#--wlan0 for use as an WLAN node
+#Bring up the p2p0 interface to start the access point
+ifconfig p2p0 up
+
+
 cd /usr/share/wpa_ap
 
-for index in {1..10}:
+#for index in {1..10}:
+#do
+#	wlan0_status=$(wpa_cli -i wlan0 ping)
+#	if [ $wlan0_status == "PONG" ]; then
+#		wlan0_found=true
+#		break
+#	fi
+#	sleep 1
+#done
+
+while ! ifconfig p2p0 up
 do
-	wlan0_status=$(wpa_cli -i wlan0 ping)
-	if [ $wlan0_status == "PONG" ]; then
-		wlan0_found=true
-		break
-	fi
 	sleep 1
 done
 
 
 #Create a new managed mode interface wlan1 to run AP
-iw phy phy0 interface add wlan1 type managed
+#iw phy phy0 interface add wlan1 type managed
+iw phy phy0 interface add p2p0 type managed
 
-hid=$(ifconfig -a | grep wlan1 | sed "s,wlan1.*HWaddr \(.*\),\1," | tr -d ": ")
+#hid=$(ifconfig -a | grep wlan1 | sed "s,wlan1.*HWaddr \(.*\),\1," | tr -d ": ")
+hid=$(ifconfig -a | grep p2p0 | sed "s,p2p0.*HWaddr \(.*\),\1," | tr -d ": ")
+
 ip=192.168.2.1
 
-sed "s,Ultra96,Ultra96_$hid," wpa_ap.conf > wpa_ap_actual.conf
+sed "s,Ultra96,Ultra96-V2_$hid," wpa_ap.conf > wpa_ap_actual.conf
 
-ifdown wlan1
+#ifdown wlan1
+ifdown p2p0
+
 sleep 2
-wpa_supplicant -c ./wpa_ap_actual.conf  -iwlan1 &
 
-ifconfig wlan1 $ip
+#wpa_supplicant -c ./wpa_ap_actual.conf  -iwlan1 &
+wpa_supplicant -c ./wpa_ap_actual.conf  -ip2p0 &
+
+#ifconfig wlan1 $ip
+ifconfig p2p0 $ip
+
 touch /var/lib/misc/udhcpd.leases
 udhcpd ./udhcpd.conf

--- a/recipes-utils/ultra96-ap-setup/files/udhcpd.conf
+++ b/recipes-utils/ultra96-ap-setup/files/udhcpd.conf
@@ -1,6 +1,6 @@
 start 192.168.2.2
 end 192.168.2.254
-interface wlan1
+interface p2p0
 remaining yes
 opt subnet 255.255.255.0
 opt router 192.168.2.1


### PR DESCRIPTION
These are changes to ap.sh and udhcpd.conf to match the WiFi AP configuration required for the Ultra96-V2 board.