### PR TITLE
gstreamer-plugins-bad: Remove xlnxvideoscale support

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -20,8 +20,7 @@ SRCREV_base = "ec1ff1219c99db2a9cc5262027f9b4d20f5f4e81"
 SRCREV_common = "f0c2dc9aadfa05bb5274c40da750104ecbb88cba"
 SRCREV_FORMAT = "base"
 
-PACKAGECONFIG[xlnxvideoscale] = "--enable-xlnxvideoscale,--disable-xlnxvideoscale"
-PACKAGECONFIG_append = " faac kms faad opusparse xlnxvideoscale"
+PACKAGECONFIG_append = " faac kms faad opusparse"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
As platform which uses xlxnvideoscale is discontinued, removing this plugin.
Even underlying driver is deleted (https://gitenterprise.xilinx.com/Linux/linux-xlnx/commit/bdc7812577d9b92f683720f11ca42284166413e8#diff-2c0078857dee21c6bd0dea5efbeb389c)