### PR TITLE
fix rfdc-examples build bug. Also add more rfdc-examples recipes

### DIFF
--- a/recipes-bsp/rfdc-examples/rfdc-gen2-or-below-clocked_git.bb
+++ b/recipes-bsp/rfdc-examples/rfdc-gen2-or-below-clocked_git.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Simple rfdc-gen2-or-below-clocked application"
+
+require rfdc-examples.inc
+
+do_compile (){
+    make all BOARD_FLAG=${FLAG} OUTS=${B}/rfdc-gen2-or-below-clocked RFDC_OBJS=xrfdc_gen2_or_below_clocked_example.o
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/rfdc-gen2-or-below-clocked ${D}${bindir}
+}

--- a/recipes-bsp/rfdc-examples/rfdc-gen3-clocked_git.bb
+++ b/recipes-bsp/rfdc-examples/rfdc-gen3-clocked_git.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Simple rfdc-gen3 application"
+
+require rfdc-examples.inc
+
+do_compile (){
+    make all BOARD_FLAG=${FLAG} OUTS=${B}/rfdc-gen3-clocked RFDC_OBJS=xrfdc_gen3_clocked_example.o
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/rfdc-gen3-clocked ${D}${bindir}
+}

--- a/recipes-bsp/rfdc-examples/rfdc-mts_git.bb
+++ b/recipes-bsp/rfdc-examples/rfdc-mts_git.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Simple rfdc-mts application"
+
+require rfdc-examples.inc
+
+do_compile (){
+    make all BOARD_FLAG=${FLAG} OUTS=${B}/rfdc-mts RFDC_OBJS=xrfdc_mts_example.o
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/rfdc-mts ${D}${bindir}
+}

--- a/recipes-bsp/rfdc/rfdc_git.bb
+++ b/recipes-bsp/rfdc/rfdc_git.bb
@@ -43,6 +43,7 @@ do_install() {
     oe_libinstall -so librfdc ${D}${libdir}
     install -m 0644 xrfdc_hw.h ${D}${includedir}/xrfdc_hw.h
     install -m 0644 xrfdc.h ${D}${includedir}/xrfdc.h
+    install -m 0644 xrfdc_mts.h ${D}${includedir}/xrfdc_mts.h
 }
 
 FILES_${PN} = "${libdir}/*.so.*"


### PR DESCRIPTION
I was getting an error compiling the rfdc-examples when including the meta-petalinux in a traditional Yocto flow. The issue was in xrfdc_mts.h missing in sysroots.

Also just added some more recipes by copying other examples