### PR TITLE
Fix device-tree sstate cache dependency on build location

### DIFF
--- a/dynamic-layers/xilinx-core/recipes-bsp/device-tree/device-tree.bbappend
+++ b/dynamic-layers/xilinx-core/recipes-bsp/device-tree/device-tree.bbappend
@@ -14,7 +14,7 @@ python () {
             d.prependVar('FILESEXTRAPATHS', '%s:' % sysconfig_dir)
         if plnx_scriptspath:
             d.prependVar('FILESEXTRAPATHS', '%s:' % plnx_scriptspath)
-            d.appendVar('SRC_URI', ' file://%s' % plnx_scriptspath)
+            d.appendVar('SRC_URI', ' file://petalinux_hsm_bridge.tcl file://data/ipinfo.yaml')
 }
 
 do_configure:append () {


### PR DESCRIPTION
Related to #34

Update `SRC_URI` in `device-tree.bbappend` to avoid using the full path to the PetaLinux scripts directory.

* Remove the line that appends `plnx_scriptspath` to `SRC_URI`.
* Append the names of the particular scripts needed under `plnx_scriptspath` to `SRC_URI`.

