### PR TITLE
Add support for Yocto LTS releases

### DIFF
--- a/conf/distro/petalinux.conf
+++ b/conf/distro/petalinux.conf
@@ -12,7 +12,7 @@ DISTRO = "petalinux"
 DISTRO_NAME = "PetaLinux"
 
 # Define the ROS2 Yocto release
-ROS_OE_RELEASE_SERIES = "mickledore"
+ROS_OE_RELEASE_SERIES = "mickledore langdale"
 
 # Define ROS2 distro release
 ROS_DISTRO = "humble"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -60,4 +60,4 @@ SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
 	"
 BB_DANGLINGAPPENDS_WARNONLY = "true"
 
-LAYERSERIES_COMPAT_petalinux = "nanbield"
+LAYERSERIES_COMPAT_petalinux = "nanbield langdale mickledore"


### PR DESCRIPTION
Related to #29

Add support for Yocto LTS releases.

* Update `conf/distro/petalinux.conf` to include "langdale" in the `ROS_OE_RELEASE_SERIES` variable.
* Update `conf/layer.conf` to include "langdale" and "mickledore" in the `LAYERSERIES_COMPAT_petalinux` variable. 

