### PR TITLE
Fix XSCT URL for rel-v2022.2

### DIFF
--- a/conf/distro/include/petalinux-version.conf
+++ b/conf/distro/include/petalinux-version.conf
@@ -1,8 +1,8 @@
 # Main release version
-XILINX_VER_MAIN = "2023.2"
+XILINX_VER_MAIN = "2022.2"
 
 # Set to "release" for major releases and "update-1" for update releases
-XILINX_VER_UPDATE = "snapshot"
+XILINX_VER_UPDATE = "release"
 
 # This will be set in local.conf for CI builds
 XILINX_VER_BUILD ?= "${@'${METADATA_REVISION}' if d.getVar('METADATA_REVISION') != '<unknown>' else 'unknown'}"


### PR DESCRIPTION
Related to #26

Update `XILINX_VER_MAIN` and `XILINX_VER_UPDATE` in `conf/distro/include/petalinux-version.conf` to match the 2022.2 release version.

* Change `XILINX_VER_MAIN` from "2023.2" to "2022.2".
* Change `XILINX_VER_UPDATE` from "snapshot" to "release".

